### PR TITLE
Fix assertion failures on Groovy/Gradle files

### DIFF
--- a/src/main/java/org/openrewrite/java/joda/time/ScopeAwareVisitor.java
+++ b/src/main/java/org/openrewrite/java/joda/time/ScopeAwareVisitor.java
@@ -44,7 +44,10 @@ class ScopeAwareVisitor extends JavaVisitor<ExecutionContext> {
             scopes.push(new VariablesInScope(getCursor()));
         }
         if (j instanceof J.VariableDeclarations.NamedVariable) {
-            assert !scopes.isEmpty();
+            if (scopes.isEmpty()) {
+                // Script-level variables in Groovy don't have a containing scope
+                return super.preVisit(j, ctx);
+            }
             NamedVariable variable = (NamedVariable) j;
             scopes.peek().variables.add(variable);
         }


### PR DESCRIPTION
## Problem

`ScopeAwareVisitor` and `VarTable` throw `AssertionError` when processing Groovy or Gradle files:

```
java.lang.AssertionError: null
    at org.openrewrite.java.joda.time.ScopeAwareVisitor.preVisit(ScopeAwareVisitor.java:47)
```

```
java.lang.AssertionError: null
    at org.openrewrite.java.joda.time.JodaTimeRecipe$VarTable.addVars(JodaTimeRecipe.java:68)
```

This happens because:
1. `JodaTimeScanner` has no precondition limiting it to Java files
2. `G.CompilationUnit` implements `JavaSourceFile`, so Groovy files are visited
3. Script-level variables in Groovy scripts have no containing scope (`ScopeAwareVisitor`)
4. Groovy methods may not have type information (`VarTable`)

## Solution

Handle these edge cases gracefully by returning early instead of asserting. Script-level variables and untyped methods are not relevant for Joda-Time migration since they're outside the context where the recipes would apply.