### PR TITLE
Fix assertion failure on JavaScript files in JodaTimeRecipe

### DIFF
--- a/src/main/java/org/openrewrite/java/joda/time/JodaTimeRecipe.java
+++ b/src/main/java/org/openrewrite/java/joda/time/JodaTimeRecipe.java
@@ -65,7 +65,10 @@ public class JodaTimeRecipe extends ScanningRecipe<JodaTimeRecipe.Accumulator> {
 
         public void addVars(J.MethodDeclaration methodDeclaration) {
             JavaType type = methodDeclaration.getMethodType();
-            assert type != null;
+            if (type == null) {
+                // Method type is not available in some non-Java source files (JS, Groovy, etc.)
+                return;
+            }
             methodDeclaration.getParameters().forEach(p -> {
                 if (!(p instanceof J.VariableDeclarations)) {
                     return;

--- a/src/main/java/org/openrewrite/java/joda/time/ScopeAwareVisitor.java
+++ b/src/main/java/org/openrewrite/java/joda/time/ScopeAwareVisitor.java
@@ -23,6 +23,8 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.J.VariableDeclarations.NamedVariable;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Optional;
@@ -45,7 +47,7 @@ class ScopeAwareVisitor extends JavaVisitor<ExecutionContext> {
         }
         if (j instanceof J.VariableDeclarations.NamedVariable) {
             if (scopes.isEmpty()) {
-                // Script-level variables in Groovy don't have a containing scope
+                // Variables in non-Java source files (JS, Groovy, etc.) may lack a containing scope
                 return super.preVisit(j, ctx);
             }
             NamedVariable variable = (NamedVariable) j;
@@ -89,9 +91,8 @@ class ScopeAwareVisitor extends JavaVisitor<ExecutionContext> {
         return Optional.empty();
     }
 
-    Cursor getCurrentScope() {
-        assert !scopes.isEmpty();
-        return scopes.peek().scope;
+    @Nullable Cursor getCurrentScope() {
+        return scopes.isEmpty() ? null : scopes.peek().scope;
     }
 
     @Value

--- a/src/test/java/org/openrewrite/java/joda/time/JodaTimeRecipeTest.java
+++ b/src/test/java/org/openrewrite/java/joda/time/JodaTimeRecipeTest.java
@@ -505,4 +505,29 @@ class JodaTimeRecipeTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void handlesSourcesWithMissingTypeInformation() {
+        // When running on sources without full type attribution (e.g., missing classpath),
+        // the recipe should gracefully skip rather than throw NPE or AssertionError.
+        // This simulates the scenario encountered with JS/Groovy files that lack type info.
+        rewriteRun(
+          spec -> spec
+            .parser(JavaParser.fromJavaVersion()) // no joda-time classpath
+            .typeValidationOptions(org.openrewrite.test.TypeValidation.none()),
+          //language=java
+          java(
+            """
+              import org.joda.time.DateTime;
+
+              class A {
+                  public void foo() {
+                      DateTime dt = new DateTime();
+                      System.out.println(dt.toString());
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Problem

The `VarTable.addVars()` method in `JodaTimeRecipe` asserts that `methodDeclaration.getMethodType()` is non-null. However, this can be null for JavaScript and other non-Java source files that lack full type attribution, causing an `AssertionError`:

```
java.lang.AssertionError: null
  org.openrewrite.java.joda.time.JodaTimeRecipe$VarTable.addVars(JodaTimeRecipe.java:68)
  org.openrewrite.java.joda.time.JodaTimeScanner.visitMethodDeclaration(JodaTimeScanner.java:157)
```

- This is the same class of issue as #9, but in a different location.

## Solution

Replace the assertion with an early return when `getMethodType()` returns null, following the same pattern used in `ScopeAwareVisitor`.